### PR TITLE
Fix MinimumSupportedWindowsRelease to current IntuneWin32App Syntax

### DIFF
--- a/sources/WingetIntunePackager.ps1
+++ b/sources/WingetIntunePackager.ps1
@@ -510,7 +510,7 @@ function Invoke-IntunePackage ($Win32AppArgs) {
     }
 
     # Create requirement rule for all platforms and Windows 10 2004
-    $RequirementRule = New-IntuneWin32AppRequirementRule -Architecture "All" -MinimumSupportedWindowsRelease "2004"
+    $RequirementRule = New-IntuneWin32AppRequirementRule -Architecture "All" -MinimumSupportedWindowsRelease "w10_2004"
 
     # Create MSI detection rule
     $DetectionRule = New-IntuneWin32AppDetectionRuleScript -ScriptFile "$DetectionScriptPath\$DetectionScriptFile"


### PR DESCRIPTION
Fix -MinimumSupportedWindowsRelease syntax to work with current release of IntuneWin32App. Syntax now calls for W10_ prefix.